### PR TITLE
Support injecting filepath of source file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,21 @@ The buttons can be configured in **book.json**:
                     "icon": "fa fa-twitter",
                     "position":"left",
                     "url": "http://twitter.com/home?status={{title}}%20{{url}}"
+                },
+                {
+                    "label": "Edit page on github",
+                    "icon": "fa fa-pencil-square-o",
+                    "position" : "left",
+                    "url": "https://github.com/org/repo/edit/master/{{filepath_lang}}"
                 }
+                
             ]
         }
     }
 }
 ```
+
+### Button parameters
 
 The table below lists the default values of the optional button parameters:
 
@@ -50,4 +59,15 @@ Button | Default
 Label | Link
 Icon | fa-external-link
 Position | right
+
+### Format strings
+
+The following format strings can be used in your urls:
+
+String | Description
+---|---
+{{title}} | Title of page
+{{url}} | URL of current page
+{{filepath_lang}} | Filepath of the *source* page. This includes the language code in a multilingual book.
+
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@ This plugin adds buttons with external links to a Gitbook website toolbar.
 
 ### Configuration
 
-This plugin can be configured in `book.json`:
+The buttons can be configured in **book.json**:
 
 ```js
 {
+    "plugins": [
+        "toolbar"
+    ],
     "pluginsConfig": {
         "toolbar": {
             "buttons":
@@ -31,6 +34,7 @@ This plugin can be configured in `book.json`:
                 {
                     "label": "Share page title and link on Twitter",
                     "icon": "fa fa-twitter",
+                    "position":"left",
                     "url": "http://twitter.com/home?status={{title}}%20{{url}}"
                 }
             ]
@@ -38,4 +42,12 @@ This plugin can be configured in `book.json`:
     }
 }
 ```
+
+The table below lists the default values of the optional button parameters:
+
+Button | Default
+---|---
+Label | Link
+Icon | fa-external-link
+Position | right
 

--- a/assets/buttons.js
+++ b/assets/buttons.js
@@ -18,7 +18,7 @@ require(['gitbook'], function(gitbook) {
                     var mapping = {
                         "{{title}}": encodeURIComponent(document.title),
                         "{{url}}": encodeURIComponent(location.href),
-                        "{{filepath}}": encodeURIComponent((gitbook.state.innerLanguage ? gitbook.state.innerLanguage+'/' : '')+gitbook.state.filepath)
+                        "{{filepath_lang}}": encodeURIComponent((gitbook.state.innerLanguage ? gitbook.state.innerLanguage+'/' : '')+gitbook.state.filepath)
                     };
                     var re = RegExp(Object.keys(mapping).join("|"), "g");
                     var url = button.url.replace(re, function(matched) {

--- a/assets/buttons.js
+++ b/assets/buttons.js
@@ -12,7 +12,7 @@ require(['gitbook'], function(gitbook) {
             gitbook.toolbar.createButton({
                 icon: button.icon || "fa fa-external-link",
                 label: button.label || "Link",
-                position: 'right',
+                position: button.position || "right",
                 onClick: function(e) {
                     e.preventDefault();
                     var mapping = {

--- a/assets/buttons.js
+++ b/assets/buttons.js
@@ -17,7 +17,8 @@ require(['gitbook'], function(gitbook) {
                     e.preventDefault();
                     var mapping = {
                         "{{title}}": encodeURIComponent(document.title),
-                        "{{url}}": encodeURIComponent(location.href)
+                        "{{url}}": encodeURIComponent(location.href),
+                        "{{filepath}}": encodeURIComponent((gitbook.state.innerLanguage ? gitbook.state.innerLanguage+'/' : '')+gitbook.state.filepath)
                     };
                     var re = RegExp(Object.keys(mapping).join("|"), "g");
                     var url = button.url.replace(re, function(matched) {


### PR DESCRIPTION
This allows you to specify a {{filepath}} (as well as url and title). This then allows the plugin to be used to create links to edit the page on github. The path includes the language code, if one has been defined. It does not include a leading forward slash. 

